### PR TITLE
Feature listener annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,48 @@ This library is trying to work with AWS SDK as closely as possible. To use it,
 you can often refer to the official documentation, as under the hood these methods often are just
 `return sqs.method(request).promise()`.
 
+### QueueListener
+
+The package also provides a TypeScript decorator for class methods. Methods
+annotated with `@QueueListener` will automatically be trigerred upon receiving
+a message from SQS.
+
+The signature is as follows
+
+```typescript
+@QueueListener<T> (
+  // A consumer instance, queue consumer config or a queue URL.
+  consumerConfig: QueueConsumer<T> | QueueConsumerConfig | string,
+  // Custom transformation function, defaults to JSON.parse.
+  transform: (body: string) => T = JSON.parse,
+  // Message deletion policy. Provides NEVER, ALWAYS and ON_SUCCESS and defaults
+  // to the latter.
+  deletionPolicy: DeletionPolicy = DeletionPolicy.ON_SUCCESS,
+)
+```
+
+#### Example
+
+```typescript
+interface Todo {
+  title: string
+  completed: boolean
+}
+
+class Controller {
+
+  @QueueListener<Todo>('http://my-queue-url')
+  public handleMessage (message: QueueMessage<Todo>, app: QueueConsumer<Todo>) : void {
+    console.assert(typeof message.body.title === 'string')
+    console.assert(typeof message.body.titcompletedle === 'boolean')
+
+    // Also provides the consumer instance to stop polling.
+    console.assert(typeof app.stop === 'function')
+  }
+
+}
+```
+
 ----
 
 ## Open source licensing info

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ class Controller {
   @QueueListener<Todo>('http://my-queue-url')
   public handleMessage (message: QueueMessage<Todo>, app: QueueConsumer<Todo>) : void {
     console.assert(typeof message.body.title === 'string')
-    console.assert(typeof message.body.titcompletedle === 'boolean')
+    console.assert(typeof message.body.completed === 'boolean')
 
     // Also provides the consumer instance to stop polling.
     console.assert(typeof app.stop === 'function')

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ The package also provides a TypeScript decorator for class methods. Methods
 annotated with `@QueueListener` will automatically be trigerred upon receiving
 a message from SQS.
 
-The signature is as follows
+The signature is as follows:
 
 ```typescript
 @QueueListener<T> (

--- a/src/DeletionPolicy.ts
+++ b/src/DeletionPolicy.ts
@@ -1,0 +1,9 @@
+
+/**
+ * The message deletion policy enumeration.
+ */
+export enum DeletionPolicy {
+  ALWAYS,
+  NEVER,
+  ON_SUCCESS,
+}

--- a/src/annotations.ts
+++ b/src/annotations.ts
@@ -1,0 +1,54 @@
+import { SQS } from 'aws-sdk'
+import { QueueConsumer } from './QueueConsumer'
+import { DeletionPolicy } from './DeletionPolicy'
+import { QueueConsumerConfig } from './QueueConsumerConfig'
+
+/**
+ * The @Listener method annotation to create a listener for AWS SQS messages.
+ * This method is then automatically trigerred upon receiving a message.
+ *
+ * @param consumerConfig The consumer configuration, the queue URL or the consumer itself
+ * @param transform The message transformer
+ * @param deletionPolicy The message deletion policy
+ */
+export function QueueListener<T> (
+  consumerConfig: QueueConsumer<T> | QueueConsumerConfig | string,
+  transform: (body: string) => T = JSON.parse,
+  deletionPolicy: DeletionPolicy = DeletionPolicy.ON_SUCCESS,
+) : MethodDecorator {
+  return (target, key) => {
+    // Merge the configuration to one type.
+    let app: QueueConsumer<T>
+
+    if (consumerConfig instanceof QueueConsumer) {
+      app = consumerConfig
+    } else {
+      const config: QueueConsumerConfig = typeof consumerConfig === 'string'
+        ? { request: { QueueUrl: consumerConfig }, interval: 1000 }
+        : consumerConfig
+
+      app = new QueueConsumer(new SQS(), config, transform)
+    }
+
+    app.onMessage.addListener(async (message) => {
+      try {
+        await target[key](message, app)
+
+        // If the deletion policy is to delete on success or always, delete the
+        // message.
+        if (deletionPolicy === DeletionPolicy.ON_SUCCESS || deletionPolicy === DeletionPolicy.ALWAYS) {
+          message.delete()
+        }
+      } catch (e) {
+        // If the deletion policy is to delete always, delete the message.
+        if (deletionPolicy === DeletionPolicy.ALWAYS) {
+          message.delete()
+        }
+
+        throw e
+      }
+    })
+
+    app.run()
+  }
+}

--- a/src/annotations.ts
+++ b/src/annotations.ts
@@ -1,5 +1,6 @@
 import { SQS } from 'aws-sdk'
 import { QueueConsumer } from './QueueConsumer'
+import { ListenerException } from './exceptions'
 import { DeletionPolicy } from './DeletionPolicy'
 import { QueueConsumerConfig } from './QueueConsumerConfig'
 
@@ -40,6 +41,8 @@ export function QueueListener<T> (
         if (deletionPolicy === DeletionPolicy.ON_SUCCESS) {
           message.delete()
         }
+      } catch (e) {
+        app.onError.dispatch(new ListenerException(e))
       } finally {
         // If the deletion policy is to delete on always, delete the message.
         if (deletionPolicy === DeletionPolicy.ALWAYS) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,19 @@ export { QueueConsumerConfig } from './QueueConsumerConfig'
 export { QueueMessage } from './QueueMessage'
 
 /**
+ * Exports message deletion policy enumeration.
+ */
+
+export { DeletionPolicy } from './DeletionPolicy'
+
+/**
  * Exports the exceptions classes.
  */
 
 export * from './exceptions'
+
+/**
+ * Exports annotations.
+ */
+
+export * from './annotations'

--- a/test/spec/QueueListener.spec.ts
+++ b/test/spec/QueueListener.spec.ts
@@ -2,7 +2,14 @@ import { expect } from 'chai'
 import * as sinon from 'sinon'
 
 import { SQS } from 'aws-sdk'
-import { QueueListener, QueueConsumer, QueueConsumerConfig, QueueMessage } from '../../src'
+
+import {
+  QueueMessage,
+  QueueConsumer,
+  QueueListener,
+  DeletionPolicy,
+  QueueConsumerConfig,
+} from '../../src'
 
 describe('QueueListener annotation', () => {
   let sqs: SQS
@@ -44,6 +51,110 @@ describe('QueueListener annotation', () => {
           done()
         } catch (e) { done(e) }
 
+        app.stop()
+      }
+    }
+  })
+
+  it('correctly handles NEVER deletion policy', (done) => {
+    ;(sqs.receiveMessage as sinon.SinonStub)
+      .withArgs(config.request)
+      .returns({
+        promise: () => Promise.resolve({
+          Messages: [
+            { Body: '{"title":"test","completed":true}' }
+          ]
+        })
+      })
+
+    ;(sqs.deleteMessage as sinon.SinonStub)
+      .returns({
+        promise: async () => done(new Error('should not have been called'))
+      })
+
+    class Service {
+      @QueueListener<Todo>(consumer, JSON.parse, DeletionPolicy.NEVER)
+      public queueListener (message: QueueMessage<Todo>, app: QueueConsumer<Todo>) {
+        try {
+          expect(message.body).to.deep.equal({ title: 'test', completed: true })
+          done()
+        } catch (e) { done(e) }
+
+        app.stop()
+      }
+    }
+  })
+
+  it('correctly handles ALWAYS deletion policy', (done) => {
+    ;(sqs.receiveMessage as sinon.SinonStub)
+      .withArgs(config.request)
+      .returns({
+        promise: () => Promise.resolve({
+          Messages: [
+            { Body: '{"title":"test","completed":true}' }
+          ]
+        })
+      })
+
+    ;(sqs.deleteMessage as sinon.SinonStub)
+      .returns({
+        promise: async () => done()
+      })
+
+    class Service {
+      @QueueListener<Todo>(consumer, JSON.parse, DeletionPolicy.ALWAYS)
+      public queueListener (message: QueueMessage<Todo>, app: QueueConsumer<Todo>) {
+        app.stop()
+        throw new Error
+      }
+    }
+  })
+
+  it('correctly handles ON_SUCCESS deletion policy (1)', (done) => {
+    ;(sqs.receiveMessage as sinon.SinonStub)
+      .withArgs(config.request)
+      .returns({
+        promise: () => Promise.resolve({
+          Messages: [
+            { Body: '{"title":"test","completed":true}' }
+          ]
+        })
+      })
+
+    ;(sqs.deleteMessage as sinon.SinonStub)
+      .returns({
+        promise: async () => done(new Error('should not have been called'))
+      })
+
+    class Service {
+      @QueueListener<Todo>(consumer, JSON.parse, DeletionPolicy.ON_SUCCESS)
+      public queueListener (message: QueueMessage<Todo>, app: QueueConsumer<Todo>) {
+        done()
+        app.stop()
+        throw new Error
+      }
+    }
+  })
+
+  it('correctly handles ON_SUCCESS deletion policy (2)', (done) => {
+    ;(sqs.receiveMessage as sinon.SinonStub)
+      .withArgs(config.request)
+      .returns({
+        promise: () => Promise.resolve({
+          Messages: [
+            { Body: '{"title":"test","completed":true}' }
+          ]
+        })
+      })
+
+    ;(sqs.deleteMessage as sinon.SinonStub)
+      .returns({
+        promise: async () => done()
+      })
+
+    class Service {
+      @QueueListener<Todo>(consumer, JSON.parse, DeletionPolicy.ON_SUCCESS)
+      public queueListener (message: QueueMessage<Todo>, app: QueueConsumer<Todo>) {
         app.stop()
       }
     }

--- a/test/spec/QueueListener.spec.ts
+++ b/test/spec/QueueListener.spec.ts
@@ -1,0 +1,57 @@
+import { expect } from 'chai'
+import * as sinon from 'sinon'
+
+import { SQS } from 'aws-sdk'
+import { QueueListener, QueueConsumer, QueueConsumerConfig, QueueMessage } from '../../src'
+
+describe('QueueListener annotation', () => {
+  let sqs: SQS
+  let consumer: QueueConsumer<Todo>
+  let config: QueueConsumerConfig
+
+  beforeEach(() => {
+    sqs = new SQS()
+    config = {
+      request: { QueueUrl: 'test-queue' },
+      interval: 10,
+    }
+    consumer =  new QueueConsumer(sqs, config, JSON.parse)
+    sinon.stub(sqs, 'receiveMessage')
+    sinon.stub(sqs, 'deleteMessage')
+  })
+
+  it('polls for a message using a provided consumer', (done) => {
+    ;(sqs.receiveMessage as sinon.SinonStub)
+      .withArgs(config.request)
+      .returns({
+        promise: () => Promise.resolve({
+          Messages: [
+            { Body: '{"title":"test","completed":true}' }
+          ]
+        })
+      })
+
+    ;(sqs.deleteMessage as sinon.SinonStub)
+      .returns({
+        promise: () => Promise.resolve()
+      })
+
+    class Service {
+      @QueueListener<Todo>(consumer)
+      public queueListener (message: QueueMessage<Todo>, app: QueueConsumer<Todo>) {
+        try {
+          expect(message.body).to.deep.equal({ title: 'test', completed: true })
+          done()
+        } catch (e) { done(e) }
+
+        app.stop()
+      }
+    }
+  })
+
+})
+
+interface Todo {
+  title: string
+  completed: boolean
+}


### PR DESCRIPTION
This is inspired by Spring Boot's `SqsListener` annotation that triggers class methods upon receiving a message from AWS SQS. It is a very handy feature that strips a lot of code needed to do basic queue polling in an elegant way.

## Changes

- Added the `QueueListener<T>` annotation
- Added the `DeletionPolicy` enumeration

## Testing

1. Added a test that checks whether the basic functionality is correct

## Notes

- Tests are not too thorough as testing TypeScript decorators is a pain. I have no way to mock any functionality inside the decorator.
- I did not come up with an elegant way to handle errors. It could either stop the polling, ignore errors or log them. Might be overkill but it could be done via implementing and `ErrorPolicy` enum.